### PR TITLE
Catches DeserializeCommand exceptions rethrowing as HttpProblemDetailsException

### DIFF
--- a/src/Cedar.CommandHandling.Http/Http/CommandHandlingSettings.cs
+++ b/src/Cedar.CommandHandling.Http/Http/CommandHandlingSettings.cs
@@ -1,6 +1,6 @@
 namespace Cedar.CommandHandling.Http
 {
-    using Cedar.CommandHandling;
+    using System;
     using Cedar.CommandHandling.Http.Properties;
     using Cedar.CommandHandling.Http.TypeResolution;
     using CuttingEdge.Conditions;
@@ -9,6 +9,8 @@ namespace Cedar.CommandHandling.Http
     {
         private readonly ICommandHandlerResolver _handlerResolver;
         private readonly ResolveCommandType _resolveCommandType;
+        private DeserializeCommand _deserializeCommand;
+        private MapProblemDetailsFromException _mapProblemDetailsFromException;
         private ParseMediaType _parseMediaType = MediaTypeParsers.AllCombined;
         private MapProblemDetailsFromException _mapProblemDetailsFromException;
         private DeserializeCommand _deserializeCommand;
@@ -22,7 +24,7 @@ namespace Cedar.CommandHandling.Http
             : this(
                 handlerResolver,
                 CommandTypeResolvers.FullNameWithUnderscoreVersionSuffix(handlerResolver.KnownCommandTypes))
-        { } 
+        {}
 
         public CommandHandlingSettings(
             [NotNull] ICommandHandlerResolver handlerResolver,

--- a/src/Cedar.CommandHandling.Tests/CommandHandlingSettingsTests.cs
+++ b/src/Cedar.CommandHandling.Tests/CommandHandlingSettingsTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace Cedar.CommandHandling
 {
+    using System;
     using Cedar.CommandHandling.Http;
     using Cedar.CommandHandling.Http.TypeResolution;
     using FakeItEasy;
@@ -17,6 +18,52 @@
             sut.ParseMediaType = parseMediaType;
 
             sut.ParseMediaType.Should().Be(parseMediaType);
+        }
+
+        [Fact]
+        public void When_deserializer_throws_then_should_throw_HttpProblemDetailsException()
+        {
+            var sut = new CommandHandlingSettings(A.Fake<ICommandHandlerResolver>(), A.Fake<ResolveCommandType>());
+
+            Action act = () => sut.DeserializeCommand("xyz", typeof(CommandHandlingSettingsTests));
+
+            act.ShouldThrowExactly<HttpProblemDetailsException<HttpProblemDetails>>()
+                .And.ProblemDetails.Status.Should().Be(400);
+        }
+
+        [Fact]
+        public void When_custom_deserializer_throws_then_should_throw_HttpProblemDetailsException()
+        {
+            var sut = new CommandHandlingSettings(A.Fake<ICommandHandlerResolver>(), A.Fake<ResolveCommandType>())
+            {
+                DeserializeCommand = (_, __) => { throw new Exception(); }
+            };
+
+            Action act = () => sut.DeserializeCommand("xyz", typeof(CommandHandlingSettingsTests));
+
+            act.ShouldThrowExactly<HttpProblemDetailsException<HttpProblemDetails>>();
+        }
+
+        [Fact]
+        public void When_custom_deserializer_throws_HttpProblemDetailsException_then_it_should_propagate()
+        {
+            var expected = new HttpProblemDetailsException<HttpProblemDetails>(new HttpProblemDetails());
+            var sut = new CommandHandlingSettings(A.Fake<ICommandHandlerResolver>(), A.Fake<ResolveCommandType>())
+            {
+                DeserializeCommand = (_, __) => { throw expected; }
+            };
+
+            Exception thrown = null;
+            try
+            {
+                sut.DeserializeCommand("xyz", typeof(CommandHandlingSettingsTests));
+            }
+            catch(Exception ex)
+            {
+                thrown = ex;
+            }
+
+            thrown.Should().Be(expected);
         }
     }
 }


### PR DESCRIPTION
Will bubble up HttpProblemDetailsException if the deserializer originally threw that.

Ping @yreynhout for review.