### PR TITLE
Server side optimizations in case of large payloads.

### DIFF
--- a/src/Cedar.CommandHandling.Example/09_CustomSerialization.cs
+++ b/src/Cedar.CommandHandling.Example/09_CustomSerialization.cs
@@ -1,0 +1,80 @@
+﻿/*
+ * Example of how to invoke the CommandHandlingMiddleware using an embedded HTTP pipline
+ * 
+ * This is a achieved by using OwinHttpMessageHandler (https://github.com/damianh/OwinHttpMessageHandler)
+ * that allows an instance of HTTP client send an HTTP request directly to the middleware
+ * without requiring an actual HTTP server, and the associated enviromental dependencies.
+ * 
+ * This is useful for two scenarios:
+ * 
+ * 1. Tests where you want to cover the entire pipline of handlers, serialization,
+ *    type resolution etc.
+ *    
+ * 2. Invoking your "remote" HTTP API in proc. The has the advantage of using the
+ *    exact same pipline as remote clients. (Disadvantage is a slower invocation than
+ *    a method call)
+ * 
+ * Here we are showing a test.
+ */
+
+// ReSharper disable once CheckNamespace
+namespace Cedar.CommandHandling.Example.CustomSerialization
+{
+    using System;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using Cedar.CommandHandling;
+    using Cedar.CommandHandling.Http;
+    using Newtonsoft.Json;
+    using Xunit;
+
+    public class Command
+    {}
+
+    public class CommandModule : CommandHandlerModule
+    {
+        public CommandModule()
+        {
+            For<Command>()
+                .Handle((_, __) => Task.FromResult(0));
+        }
+    }
+
+    public class CusomSerializationTests
+    {
+        [Fact]
+        public async Task Can_invoke_command_over_http()
+        {
+            var resolver = new CommandHandlerResolver(new CommandModule());
+            // 1. Create the serializer
+            var jsonSerializer = new JsonSerializer();
+            var settings = new CommandHandlingSettings(resolver)
+            {
+                // 2. Customize the deserialization
+                DeserializeCommand = (commandReader, type) =>
+                {
+                    using(var reader = new JsonTextReader(commandReader))
+                    {
+                        return jsonSerializer.Deserialize(reader, type);
+                    }
+                }
+            };
+            var middleware = CommandHandlingMiddleware.HandleCommands(settings);
+
+            // 3. Customize the serialization
+            SerializeCommand serializeCommand = (writer, command) =>
+            {
+                jsonSerializer.Serialize(writer, command);
+            };
+            // 3. Create an embedded HttpClient. This allows invoking of the 
+            //    HttpPipeline in-memory without a server / listener.
+            using(HttpClient client = middleware.CreateEmbeddedClient())
+            {
+                // 3. This is as close as you can get to simulating a real client call
+                //    without needing real server. 
+                //    Can use this to do acceptance testing also.
+                await client.PutCommand(new Command(), Guid.NewGuid(), serializeCommand: serializeCommand);
+            }
+        }
+    }
+}

--- a/src/Cedar.CommandHandling.Example/Cedar.CommandHandling.Example.csproj
+++ b/src/Cedar.CommandHandling.Example/Cedar.CommandHandling.Example.csproj
@@ -50,6 +50,10 @@
     <Reference Include="Microsoft.Owin.Hosting">
       <HintPath>..\packages\Microsoft.Owin.Hosting.3.0.1\lib\net45\Microsoft.Owin.Hosting.dll</HintPath>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
@@ -72,6 +76,7 @@
     <Compile Include="..\SharedAssemblyInfo.cs">
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="09_CustomSerialization.cs" />
     <Compile Include="08_Exceptions.cs" />
     <Compile Include="07_Embedded.cs" />
     <Compile Include="06_UnitTestingHandlers.cs" />

--- a/src/Cedar.CommandHandling.Example/packages.config
+++ b/src/Cedar.CommandHandling.Example/packages.config
@@ -4,6 +4,7 @@
   <package id="FluentValidation" version="5.5.0.0" targetFramework="net451" />
   <package id="Microsoft.Owin" version="3.0.1" targetFramework="net451" />
   <package id="Microsoft.Owin.Hosting" version="3.0.1" targetFramework="net451" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net451" />
   <package id="Owin" version="1.0" targetFramework="net451" />
   <package id="OwinHttpMessageHandler" version="1.3.1" targetFramework="net451" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net451" />

--- a/src/Cedar.CommandHandling.Http.Client/Cedar.CommandHandling.Http.Client.csproj
+++ b/src/Cedar.CommandHandling.Http.Client/Cedar.CommandHandling.Http.Client.csproj
@@ -42,6 +42,7 @@
     <Compile Include="HttpProblemDetailsException.cs" />
     <Compile Include="IHttpProblemDetailException.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SerializeCommand.cs" />
     <Compile Include="SimpleJson.cs" />
     <Compile Include="StringExtensions.cs" />
     <Compile Include="TypeExtensions.cs" />

--- a/src/Cedar.CommandHandling.Http.Client/SerializeCommand.cs
+++ b/src/Cedar.CommandHandling.Http.Client/SerializeCommand.cs
@@ -1,0 +1,13 @@
+namespace Cedar.CommandHandling.Http
+{
+    using System.IO;
+
+    /// <summary>
+    /// Delegate that represents command serialization operations.
+    /// </summary>
+    /// <param name="commandWriter">The command writer the serializer is to write to.</param>
+    /// <param name="command">The command to serialize.</param>
+    public delegate void SerializeCommand(
+        TextWriter commandWriter,
+        object command);
+}

--- a/src/Cedar.CommandHandling.Http/Cedar.CommandHandling.Http.csproj
+++ b/src/Cedar.CommandHandling.Http/Cedar.CommandHandling.Http.csproj
@@ -39,6 +39,10 @@
       <HintPath>..\packages\CuttingEdge.Conditions.1.2.0.0\lib\NET35\CuttingEdge.Conditions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.IO.RecyclableMemoryStream, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IO.RecyclableMemoryStream.1.0.0.0\lib\net45\Microsoft.IO.RecyclableMemoryStream.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.Owin">
       <HintPath>..\packages\Microsoft.Owin.3.0.1\lib\net45\Microsoft.Owin.dll</HintPath>
     </Reference>

--- a/src/Cedar.CommandHandling.Http/Http/CommandHandlingMiddleware.cs
+++ b/src/Cedar.CommandHandling.Http/Http/CommandHandlingMiddleware.cs
@@ -9,6 +9,7 @@
     using System.Web.Http.Dispatcher;
     using Cedar.CommandHandling.TinyIoC;
     using CuttingEdge.Conditions;
+    using Microsoft.IO;
     using Microsoft.Owin.Builder;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Serialization;
@@ -49,6 +50,7 @@
         {
             var container = new TinyIoCContainer();
             container.Register(settings);
+            container.Register(new RecyclableMemoryStreamManager());
 
             var config = new HttpConfiguration
             {

--- a/src/Cedar.CommandHandling.Http/Http/CommandHandlingSettings.cs
+++ b/src/Cedar.CommandHandling.Http/Http/CommandHandlingSettings.cs
@@ -76,6 +76,14 @@ namespace Cedar.CommandHandling.Http
 
         public Predispatch OnPredispatch { get; set; }
 
+        /// <summary>
+        /// Gets or sets the deserialize command delegate for custom deserialization. NOTE: if you expect that you 
+        /// may have commands whose JSON representation exceeds 85KB, it is highly recommended that you use set this
+        /// using Newtonsoft.Json or similar.
+        /// </summary>
+        /// <value>
+        /// The deserialize command.
+        /// </value>
         public DeserializeCommand DeserializeCommand
         {
             get { return _deserializeCommand; }

--- a/src/Cedar.CommandHandling.Http/Http/DeserializeCommand.cs
+++ b/src/Cedar.CommandHandling.Http/Http/DeserializeCommand.cs
@@ -1,8 +1,9 @@
 namespace Cedar.CommandHandling.Http
 {
     using System;
+    using System.IO;
 
     public delegate object DeserializeCommand(
-        string commandString,
+        TextReader commandReader,
         Type commandType);
 }

--- a/src/Cedar.CommandHandling.Http/Http/DeserializeCommand.cs
+++ b/src/Cedar.CommandHandling.Http/Http/DeserializeCommand.cs
@@ -3,6 +3,12 @@ namespace Cedar.CommandHandling.Http
     using System;
     using System.IO;
 
+    /// <summary>
+    /// Represents an operation to custom deserialize a command.
+    /// </summary>
+    /// <param name="commandReader">The command reader.</param>
+    /// <param name="commandType">Type of the command.</param>
+    /// <returns></returns>
     public delegate object DeserializeCommand(
         TextReader commandReader,
         Type commandType);

--- a/src/Cedar.CommandHandling.Http/packages.config
+++ b/src/Cedar.CommandHandling.Http/packages.config
@@ -4,6 +4,7 @@
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Owin" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.IO.RecyclableMemoryStream" version="1.0.0.0" targetFramework="net45" />
   <package id="Microsoft.Owin" version="3.0.1" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />

--- a/src/Cedar.CommandHandling.Tests/CommandHandlingSettingsTests.cs
+++ b/src/Cedar.CommandHandling.Tests/CommandHandlingSettingsTests.cs
@@ -1,6 +1,7 @@
 ﻿namespace Cedar.CommandHandling
 {
     using System;
+    using System.IO;
     using Cedar.CommandHandling.Http;
     using Cedar.CommandHandling.Http.TypeResolution;
     using FakeItEasy;
@@ -25,7 +26,13 @@
         {
             var sut = new CommandHandlingSettings(A.Fake<ICommandHandlerResolver>(), A.Fake<ResolveCommandType>());
 
-            Action act = () => sut.DeserializeCommand("xyz", typeof(CommandHandlingSettingsTests));
+            Action act = () =>
+            {
+                using(var reader = new StringReader("xyx"))
+                {
+                    sut.DeserializeCommand(reader, typeof(CommandHandlingSettingsTests));
+                }
+            };
 
             act.ShouldThrowExactly<HttpProblemDetailsException<HttpProblemDetails>>()
                 .And.ProblemDetails.Status.Should().Be(400);
@@ -39,7 +46,13 @@
                 DeserializeCommand = (_, __) => { throw new Exception(); }
             };
 
-            Action act = () => sut.DeserializeCommand("xyz", typeof(CommandHandlingSettingsTests));
+            Action act = () =>
+            {
+                using(var reader = new StringReader("xyx"))
+                {
+                    sut.DeserializeCommand(reader, typeof(CommandHandlingSettingsTests));
+                }
+            };
 
             act.ShouldThrowExactly<HttpProblemDetailsException<HttpProblemDetails>>();
         }
@@ -56,7 +69,10 @@
             Exception thrown = null;
             try
             {
-                sut.DeserializeCommand("xyz", typeof(CommandHandlingSettingsTests));
+                using (var reader = new StringReader("xyx"))
+                {
+                    sut.DeserializeCommand(reader, typeof(CommandHandlingSettingsTests));
+                }
             }
             catch(Exception ex)
             {


### PR DESCRIPTION
 - `DeserializeCommand` delegate takes a TextReader instead of a string. Allows custom serializers that are more memory usage performant and mitigates LOH usage.
 - Request streams are buffered into a pooled memory stream before deserialization (using `Microsoft.IO.RecyleableMemoryStream').
 - Added a `SerializeCommand` delegate for custom serialization on the client side. This will need to also be tweaked to prevent LOH issues, but that will be a future PR.

Fixes #20